### PR TITLE
feat: add failing jose example

### DIFF
--- a/examples/jose/package.json
+++ b/examples/jose/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vite-plugin-standalone-example-jose",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "node dist/index.js",
+    "dev": "vite",
+    "build": "rimraf dist && vite build --ssr --mode=production"
+  },
+  "files": [
+    "dist"
+  ],
+  "devDependencies": {
+    "@nitedani/vite-plugin-node": "2.0.0-alpha.1",
+    "@types/node": "^20.6.5",
+    "prettier": "^3.0.3",
+    "rimraf": "^5.0.5",
+    "typescript": "^5.2.2",
+    "vite": "v6.0.0-alpha.18"
+  },
+  "dependencies": {
+    "jose": "^5.7.0"
+  },
+  "version": "2.0.0-alpha.5"
+}

--- a/examples/jose/src/importKey.ts
+++ b/examples/jose/src/importKey.ts
@@ -1,0 +1,8 @@
+/// <reference types="vite/client" />
+
+import { importPKCS8 } from 'jose'
+
+
+const key = await importPKCS8('-----BEGIN PRIVATE KEY-----...', 'ES256')
+
+console.log(key)

--- a/examples/jose/src/importKey.ts
+++ b/examples/jose/src/importKey.ts
@@ -2,7 +2,9 @@
 
 import { importPKCS8 } from 'jose'
 
+async function main() {
+    const key = await importPKCS8('-----BEGIN PRIVATE KEY-----...', 'ES256')
+    console.log(key)
+}
 
-const key = await importPKCS8('-----BEGIN PRIVATE KEY-----...', 'ES256')
-
-console.log(key)
+main().catch(console.error)

--- a/examples/jose/tsconfig.json
+++ b/examples/jose/tsconfig.json
@@ -1,0 +1,11 @@
+{
+	"compilerOptions": {
+		"target": "es2020",
+		"module": "ESNext",
+		"esModuleInterop": true,
+		"forceConsistentCasingInFileNames": true,
+		"strict": true,
+		"skipLibCheck": true,
+		"moduleResolution": "Bundler"
+	}
+}

--- a/examples/jose/vite.config.ts
+++ b/examples/jose/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import { viteNode } from '@nitedani/vite-plugin-node/plugin'
+
+export default defineConfig({
+  plugins: [viteNode({ entry: '/src/importKey.ts', standalone: true })]
+})

--- a/packages/vite-plugin-standalone/package.json
+++ b/packages/vite-plugin-standalone/package.json
@@ -30,10 +30,11 @@
     "esbuild": "*"
   },
   "devDependencies": {
+    "@types/node": "^20.11.19",
+    "esbuild": "^0.20.1",
     "rimraf": "^3.0.2",
     "typescript": "^5.2.2",
-    "vite": "v6.0.0-alpha.18",
-    "esbuild": "^0.20.1"
+    "vite": "v6.0.0-alpha.18"
   },
   "prettier": {
     "singleQuote": true,

--- a/packages/vite-plugin-standalone/src/index.ts
+++ b/packages/vite-plugin-standalone/src/index.ts
@@ -104,7 +104,6 @@ export const standalone = (options?: StandaloneOptions): Plugin => {
           resolvedEntries,
           config,
         );
-        
       }
     },
     writeBundle(_, bundle) {

--- a/packages/vite-plugin-standalone/src/index.ts
+++ b/packages/vite-plugin-standalone/src/index.ts
@@ -29,7 +29,7 @@ export const standalone = (options?: StandaloneOptions): Plugin => {
   let root = '';
   let outDir = '';
   let outDirAbs = '';
-  let rollupEntryFilePaths: string[];
+  let rollupEntryFilePaths: string[] = [];
   let rollupResolve: any;
   // Native dependencies always need to be esbuild external
   let native: string[] = [
@@ -104,6 +104,7 @@ export const standalone = (options?: StandaloneOptions): Plugin => {
           resolvedEntries,
           config,
         );
+        
       }
     },
     writeBundle(_, bundle) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,31 @@ importers:
         specifier: v6.0.0-alpha.18
         version: 6.0.0-alpha.18(@types/node@20.14.10)
 
+  examples/jose:
+    dependencies:
+      jose:
+        specifier: ^5.7.0
+        version: 5.7.0
+    devDependencies:
+      '@nitedani/vite-plugin-node':
+        specifier: link:../../packages/vite-plugin-node
+        version: link:../../packages/vite-plugin-node
+      '@types/node':
+        specifier: ^20.6.5
+        version: 20.14.10
+      prettier:
+        specifier: ^3.0.3
+        version: 3.3.2
+      rimraf:
+        specifier: ^5.0.5
+        version: 5.0.9
+      typescript:
+        specifier: ^5.2.2
+        version: 5.5.3
+      vite:
+        specifier: v6.0.0-alpha.18
+        version: 6.0.0-alpha.18(@types/node@20.14.10)
+
   examples/nestjs:
     dependencies:
       '@nestjs/common':
@@ -319,6 +344,9 @@ importers:
         specifier: ^3.1.1
         version: 3.1.1
     devDependencies:
+      '@types/node':
+        specifier: ^20.11.19
+        version: 20.14.10
       esbuild:
         specifier: ^0.20.1
         version: 0.20.2
@@ -2630,6 +2658,9 @@ packages:
     resolution: {integrity: sha512-qH3nOSj8q/8+Eg8LUPOq3C+6HWkpUioIjDsq1+D4zY91oZvpPttw8GwtF1nReRYKXl+1AORyFqtm2f5Q1SB6/Q==}
     engines: {node: 14 >=14.21 || 16 >=16.20 || >=18}
 
+  jose@5.7.0:
+    resolution: {integrity: sha512-3P9qfTYDVnNn642LCAqIKbTGb9a1TBxZ9ti5zEVEr48aDdflgRjhspWFb6WM4PzAfFbGMJYC4+803v8riCRAKw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4541,9 +4572,9 @@ snapshots:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
       eslint-config-prettier: 8.10.0(eslint@8.57.0)
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-css-modules: 2.12.0(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       eslint-plugin-no-only-tests: 3.1.0
       eslint-plugin-react: 7.34.3(eslint@8.57.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.0)
@@ -5639,13 +5670,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 4.3.5
       enhanced-resolve: 5.17.0
       eslint: 8.57.0
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       fast-glob: 3.3.2
       get-tsconfig: 4.7.5
       is-core-module: 2.14.0
@@ -5656,14 +5687,14 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0):
+  eslint-module-utils@2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.0)(typescript@4.9.5)
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5673,7 +5704,7 @@ snapshots:
       gonzales-pe: 4.3.0
       lodash: 4.17.21
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1)(eslint@8.57.0):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlastindex: 1.2.5
@@ -5683,7 +5714,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.0
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1)(eslint@8.57.0))(eslint@8.57.0)
+      eslint-module-utils: 2.8.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@5.62.0(eslint@8.57.0)(typescript@4.9.5))(eslint@8.57.0))(eslint@8.57.0))(eslint@8.57.0)
       hasown: 2.0.2
       is-core-module: 2.14.0
       is-glob: 4.0.3
@@ -6295,6 +6326,8 @@ snapshots:
       '@isaacs/cliui': 8.0.2
     optionalDependencies:
       '@pkgjs/parseargs': 0.11.0
+
+  jose@5.7.0: {}
 
   js-tokens@4.0.0: {}
 


### PR DESCRIPTION
Hi @nitedani, 

thank you very much for making this plugin. 

It's been working really great for me so far, but now I'm trying to use the "jose" jwt library and run into an error during bundling. I've added a simple example to reproduce the problem. Any idea how to fix it? Does it maybe have something to do with native node modules imported by jose (e.g. crypto)?

```
MacBook-Pro:jose jascha$ pnpm build

> vite-plugin-standalone-example-jose@2.0.0-alpha.5 build /Users/jascha/dev/vite-plugin-standalone/examples/jose
> rimraf dist && vite build --ssr --mode=production

vite v6.0.0-alpha.18 building SSR bundle for production...
✓ 1 modules transformed.
x Build failed in 36ms
error during build:
TypeError: Cannot read properties of undefined (reading 'length')
    at Object.closeBundle (file:///Users/jascha/dev/vite-plugin-standalone/packages/vite-plugin-standalone/lib/index.js:100:49)
    at Object.handler (file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/vite@6.0.0-alpha.18_@types+node@20.14.10/node_modules/vite/dist/node/chunks/dep-DXWVQosX.js:63903:19)
    at file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/rollup@4.18.1/node_modules/rollup/dist/es/shared/node-entry.js:19743:40
    at process.processTicksAndRejections (node:internal/process/task_queues:105:5)
    at async Promise.all (index 0)
    at async PluginDriver.hookParallel (file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/rollup@4.18.1/node_modules/rollup/dist/es/shared/node-entry.js:19671:9)
    at async Object.close (file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/rollup@4.18.1/node_modules/rollup/dist/es/shared/node-entry.js:20600:13)
    at async buildEnvironment (file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/vite@6.0.0-alpha.18_@types+node@20.14.10/node_modules/vite/dist/node/chunks/dep-DXWVQosX.js:63656:13)
    at async CAC.<anonymous> (file:///Users/jascha/dev/vite-plugin-standalone/node_modules/.pnpm/vite@6.0.0-alpha.18_@types+node@20.14.10/node_modules/vite/dist/node/cli.js:874:13)
 ELIFECYCLE  Command failed with exit code 1.
MacBook-Pro:jose jascha$ 
```
